### PR TITLE
Updating actions/checkout to get rid of node16 warn

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         docker build -t swish:latest .
 


### PR DESCRIPTION
**Changes:** 

- Update actions/checkout to v4 to suppress: "Node.js 16 actions are deprecated." warning.